### PR TITLE
Added settings folder to CMakeLists.txt install section.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,3 +64,8 @@ install(TARGETS client_node
 install(DIRECTORY launch/
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
 )
+
+install(DIRECTORY settings/
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/settings
+  )
+


### PR DESCRIPTION
I got an error when trying to run this node that the file settings/client.xml could not be found. It turns out it was not getting copied from the install directory. This commit ensures that the settings folder gets copied when running install on this repo.
