### PR TITLE
Add: Parameter for frame instead of using the ns

### DIFF
--- a/launch/client.launch
+++ b/launch/client.launch
@@ -3,14 +3,15 @@
   <arg name="host" />
   <arg name="ns" default="quanergy" />
   <arg name="topic" default="points" />
+  <arg name="frame" default="quanergy" />
 
   <!-- driver -->
   <group ns="$(arg ns)">
     <node name="client_node" 
           pkg="quanergy_client_ros" 
           type="client_node" 
-          args="--host $(arg host) --settings $(find quanergy_client_ros)/settings/client.xml --frame $(arg ns) --topic $(arg topic)"
-          required="true" 
+          args="--host $(arg host) --settings $(find quanergy_client_ros)/settings/client.xml --frame $(arg frame) --topic $(arg topic)"
+          required="true"
           output="screen"/>
   </group>
 </launch>

--- a/launch/client.launch
+++ b/launch/client.launch
@@ -3,7 +3,7 @@
   <arg name="host" />
   <arg name="ns" default="quanergy" />
   <arg name="topic" default="points" />
-  <arg name="frame" default="quanergy" />
+  <arg name="frame" default="$(arg ns)" />
 
   <!-- driver -->
   <group ns="$(arg ns)">


### PR DESCRIPTION
All changes are in the ROS launch file

Before:
    The `ns` parameter is used for the topic namespace and for the
    TF-Frame

After:
    The `ns` parameter is used for the topic namespace and the new
    parameter `frame` is used for the TF-frame

Fix #14 