### PR TITLE
Actually depend on quanergy_client since it's used in the CMakeLists.txt

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -12,4 +12,6 @@
   <run_depend>sensor_msgs</run_depend>
   <build_depend>pcl_ros</build_depend>
   <run_depend>pcl_ros</run_depend>
+  <build_depend>quanergy_client</build_depend>
+  <run_depend>quanergy_client</run_depend>
 </package>


### PR DESCRIPTION
Step 2 of #9 

But unrelated, this dependency should always been listed.