### PR TITLE
launch/client.launch.py: correct import file:

### DIFF
--- a/launch/client.launch.py
+++ b/launch/client.launch.py
@@ -4,7 +4,7 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PathJoinSubstitution
-from launch.substitutions import FindPackagePrefix
+from launch_ros.substitutions import FindPackagePrefix
 
 
 def generate_launch_description():


### PR DESCRIPTION
The previous launch file depended on 'launch.substitutions' for 'FindPackagePrefix'. This has since been deprecated for ROS 2 Foxy. Consequently, the import has been changed to select from 'launch_ros.substitutions'.